### PR TITLE
Adjust style to respect original whitespace and linebreaks 

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -38,11 +38,11 @@ body {
 }
 
 code {
-	color: #fefefe;
-	font-family: 'Source Code Pro', monospace;
-	white-space: pre;
-	display: inline-block;
-	vertical-align: top;
+    color: #fefefe;
+    font-family: 'Source Code Pro', monospace;
+    white-space: pre;
+    display: inline-block;
+    vertical-align: top;
 }
 
 code em, code strong, code span {

--- a/src/style.css
+++ b/src/style.css
@@ -38,8 +38,11 @@ body {
 }
 
 code {
-    color: #fefefe;
-    font-family: 'Source Code Pro', monospace;
+	color: #fefefe;
+	font-family: 'Source Code Pro', monospace;
+	white-space: pre;
+	display: inline-block;
+	vertical-align: top;
 }
 
 code em, code strong, code span {


### PR DESCRIPTION
HTML got rid of my whitespace, making it hard to debug whitespace issues

Before:
<img width="831" height="126" alt="image" src="https://github.com/user-attachments/assets/16762d77-8720-4a44-bfa9-9e627b651882" />

After:
<img width="476" height="379" alt="image" src="https://github.com/user-attachments/assets/ed5f89c6-dac8-4a6e-bfdf-ade000d907c2" />
